### PR TITLE
Fixed mydates command

### DIFF
--- a/cogs.py
+++ b/cogs.py
@@ -190,7 +190,7 @@ class VolunteerCog(commands.Cog):
             """
             SELECT due_date, status
             FROM volunteers
-            WHERE name = ?
+            WHERE name = ? AND is_taken = 1
             """,
             (ctx.author.display_name,),
         ) as cursor:


### PR DESCRIPTION
Fixed command `!mydates` to filter correctly the dates that have been removed from the available list but showed when a user searches for their dates


This solves the issue_4:
* #4 