### PR TITLE
fix: Update logic for identification of first time contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ ipython_config.py
 #Report Files
 *_pr.json
 
+# Django welcome message cache
+django_welcome_cache.json
+
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:


### PR DESCRIPTION
- Add get_django_welcome_message() to get message that github bot uses greet first time contributor and save it in cache.
- Check the PR github actions is run on it with first time contributor mesage.

Closes: https://github.com/Pradhvan/djangonews-bot/issues/17